### PR TITLE
Adding connection handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-___
+---
 language: ruby
 
 cache:
@@ -11,3 +11,7 @@ services:
   - redis-server
 
 script: "bundle exec rspec"
+
+env:
+  global:
+    REDIS_PORT=6379

--- a/lib/redistat.rb
+++ b/lib/redistat.rb
@@ -1,2 +1,7 @@
+# require external files
+require 'redis'
+require 'active_support/core_ext'
+
 # require internal files
 require 'redistat/version'
+require 'redistat/connection'

--- a/lib/redistat/connection.rb
+++ b/lib/redistat/connection.rb
@@ -1,0 +1,13 @@
+module Redistat
+  class Connection
+    class << self
+      attr_accessor :namespace
+      attr_accessor :redis
+
+      def establish_connection(connection, namespace = nil)
+        @redis      = connection
+        @namespace  = namespace
+      end
+    end
+  end
+end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Redistat::Connection do
+  before do
+    # Reset any connections
+    Redistat::Connection.redis = nil
+    Redistat::Connection.namespace = nil
+  end
+
+  describe '#establish_connection' do
+    before do
+      redis = Redis.new(host: 'foo', port: 9000)
+      Redistat::Connection.establish_connection(redis, 'bar')
+    end
+
+    it 'properly sets the redis connection' do
+      expect(Redistat::Connection.redis.client.host).to eq('foo')
+      expect(Redistat::Connection.redis.client.port).to eq(9000)
+    end
+
+    it 'properly sets the namespace' do
+      expect(Redistat::Connection.namespace).to eq('bar')
+    end
+  end
+
+  context 'when setting options one at a time' do
+    before do
+      Redistat::Connection.redis = Redis.new(host: 'foo', port: 1111)
+      Redistat::Connection.namespace = 'bar'
+    end
+
+    it 'properly sets the redis connection' do
+      expect(Redistat::Connection.redis.client.host).to eq('foo')
+      expect(Redistat::Connection.redis.client.port).to eq(1111)
+    end
+
+    it 'properly sets the namespace' do
+      expect(Redistat::Connection.namespace).to eq('bar')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require 'redistat'
+
+RSpec.configure do |config|
+  config.before(:each) do
+  end
+end


### PR DESCRIPTION
Added a class for handling the Redis connection & application level namespace for the keys.  The application namespace allows different applications / services to utilize the same Redis instance without key collisions.

Redistat can then be configured with the following: 

```
$redis = Redis.new
Redistat::Connection.establish_connection($redis, 'app1')
```

with the namespace being optional in the establish_connection method.

Also added a couple changes to get travis to work.
