### PR TITLE
Adding Script Manager

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     atomic (1.1.14)
     coderay (1.1.0)
     diff-lcs (1.2.5)
+    dotenv (0.9.0)
     git (1.2.6)
     i18n (0.6.9)
     method_source (0.8.2)
@@ -54,6 +55,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dotenv
   git
   pry
   redistat!

--- a/lib/redistat.rb
+++ b/lib/redistat.rb
@@ -5,3 +5,4 @@ require 'active_support/core_ext'
 # require internal files
 require 'redistat/version'
 require 'redistat/connection'
+require 'redistat/script_manager'

--- a/lib/redistat/connection.rb
+++ b/lib/redistat/connection.rb
@@ -7,6 +7,7 @@ module Redistat
       def establish_connection(connection, namespace = nil)
         @redis      = connection
         @namespace  = namespace
+        Redistat::ScriptManager.load_scripts('./lib/redistat/scripts')
       end
     end
   end

--- a/lib/redistat/script_manager.rb
+++ b/lib/redistat/script_manager.rb
@@ -1,0 +1,32 @@
+module Redistat
+  class ScriptManager
+    class << self
+      def load_scripts(script_path)
+        @stored_methods = HashWithIndifferentAccess.new unless @stored_methods.is_a?(Hash)
+        Dir["#{script_path}/*.lua"].map do |file|
+          method = File.basename(file, '.*')
+          unless @stored_methods.key?(method)
+            @stored_methods[method] = Redistat::Connection.redis.script(:load, `cat #{file}`)
+          end
+        end
+      end
+
+      def method_missing(method_name, *args)
+        if @stored_methods.is_a?(Hash) && @stored_methods.key?(method_name)
+          Redistat::Connection.redis.evalsha(@stored_methods[method_name], *args)
+        else
+          fail("Could not find script: #{method_name}.lua")
+        end
+      end
+
+      def flush_scripts
+        @stored_methods = nil
+        Redistat::Connection.redis.script(:flush)
+      end
+
+      def to_ary
+        nil
+      end
+    end
+  end
+end

--- a/redistat.gemspec
+++ b/redistat.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'redis'
   gem.add_dependency 'activesupport'
 
+  gem.add_development_dependency 'dotenv'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'git'

--- a/spec/sample_scripts/sample.lua
+++ b/spec/sample_scripts/sample.lua
@@ -1,0 +1,1 @@
+return 'bar'

--- a/spec/sample_scripts/sample_with_args.lua
+++ b/spec/sample_scripts/sample_with_args.lua
@@ -1,0 +1,1 @@
+return KEYS[1]..ARGV[1]

--- a/spec/script_manager_spec.rb
+++ b/spec/script_manager_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Redistat::ScriptManager do
+  before do
+    Redistat::ScriptManager.flush_scripts
+    Redistat::ScriptManager.load_scripts('./spec/sample_scripts')
+  end
+
+  it 'allows the script to be called from the script manager' do
+    expect(Redistat::ScriptManager.sample).to eq('bar')
+  end
+
+  it 'allows keys and argv to be passed into script' do
+    keys = []
+    argv = []
+    keys << 'foo'
+    argv << 'bar'
+    expect(Redistat::ScriptManager.sample_with_args(keys, argv)).to eq('foobar')
+  end
+
+  it 'throws an error if it has not loaded the script being called' do
+    expect { Redistat::ScriptManager.foo }.to raise_error(RuntimeError)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,18 @@
 require 'redistat'
+require 'dotenv'
+
+# Using a mock redis library (such as fakeredis) for testing does not work in this situation, since it does
+# not support lua scripts or certain bitmap methods.  Thus, we need to use a real instance of redis for testing.
+# So that it does not overwrite any sensitive information on a locally running redis instance, specify the port you
+# would like the test instance of redis to run with the variable REDIS_PORT in your .env.test file.
+# Remember to boot up a redis instance on this port before running the test suite (ie. $redis-server --port 9123)
+Dotenv.load('.env.test')
+fail('Specify REDIS_PORT in your .env.test') unless ENV['REDIS_PORT'].present?
+redis = Redis.new(host: 'localhost', port: ENV['REDIS_PORT'])
 
 RSpec.configure do |config|
   config.before(:each) do
+    Redistat::Connection.redis = redis
+    Redis.current.flushdb
   end
 end


### PR DESCRIPTION
Adding a class to manage pre-loading & evaluating Lua scripts on Redis.

Example:

```
Redistat::ScriptManager.load_scripts('./lib/scripts')
```

If lib/scripts contains a file "sum.lua" then you can do: 

```
Redistat::ScriptManager.sum
```

to run the script.  

Additionally, the method takes arguments for any keys or args that need to be passed into the script:

```
keys = []
argv = []
keys << 'foo'
argv << 'bar'
Redistat::ScriptManager.sum(keys, argv)
```

@jdoconnor 
