### PR TITLE
Adding support for queries with multiple ids

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redistat (0.0.1)
+    redistat (0.1.0)
       activesupport
       redis
 

--- a/lib/redistat/scripts/data_points_for_keys.lua
+++ b/lib/redistat/scripts/data_points_for_keys.lua
@@ -1,14 +1,33 @@
-local result = {}
-local sum = 0
+-- Returns total combined sum accross all ids and keys, as well as the combined sum accross all ids for each
+-- specified data point interval
+
+local result            = {}
+local sum               = 0
+local number_of_ids     = tonumber(ARGV[1])
+local data_point_index  = 2 -- Initialized to 2 since position 1 in result is reserved for the total sum
+local count             = 1 -- Used to track whether we should should move to the next data point
 
 for index, key in ipairs(KEYS) do
-  -- For each key, add its value to the sum, and to the data points array
-  local value = tonumber(redis.call('HGET', key, ARGV[1]))
+  -- Get the value associated with the KEY + INDEX pair
+  local value = tonumber(redis.call('HGET', key, ARGV[index+1]))
+
+  -- Initialize the total value for the data point if it hasn't been initialized already
+  if result[data_point_index] == nil then
+    result[data_point_index] = 0
+  end
+
   if value then
     sum = sum + value
-    result[index+1] = value
+    result[data_point_index] = result[data_point_index] + value
+  end
+
+  -- Check if we've accounted for each id for the current data point
+  -- If true, then move to the next data point
+  if count == number_of_ids then
+    count = 1
+    data_point_index = data_point_index + 1
   else
-    result[index+1] = 0
+    count = count + 1
   end
 end
 

--- a/lib/redistat/scripts/hmfind.lua
+++ b/lib/redistat/scripts/hmfind.lua
@@ -1,0 +1,14 @@
+-- Returns an array of values for each corresponding key/index pair passed into KEYS & ARGV
+
+local result = {}
+
+for index, key in ipairs(KEYS) do
+  local value = tonumber(redis.call('HGET', key, ARGV[index]))
+  if value then
+    result[index] = value
+  else
+    result[index] = 0
+  end
+end
+
+return result

--- a/lib/redistat/scripts/hmincrby.lua
+++ b/lib/redistat/scripts/hmincrby.lua
@@ -1,7 +1,9 @@
-local id = ARGV[1]
-local incrby = ARGV[2]
+-- Increments each corresponding key/index pair passed into KEYS & ARGV
+-- SPECIAL: the first index in ARGV needs to be set to the value to increment by
+
+local incrby = ARGV[1]
 
 for index, key in ipairs(KEYS) do
-  -- For each key, increment by the passed in value
-  redis.call('HINCRBY', key, id, incrby)
+  -- For each key / id increment by the passed in value
+  redis.call('HINCRBY', key, ARGV[index+1], incrby)
 end

--- a/lib/redistat/scripts/sum.lua
+++ b/lib/redistat/scripts/sum.lua
@@ -1,8 +1,10 @@
+-- Returns the total sum of the values of each key/index pair passed into KEYS & ARGV
+
 local sum = 0
 
 for index, key in ipairs(KEYS) do
   -- For each key, read the value and add it to the total
-  local value = tonumber(redis.call('HGET', key, ARGV[1]))
+  local value = tonumber(redis.call('HGET', key, ARGV[index]))
   if value then
     sum = sum + value
   end

--- a/redistat.gemspec
+++ b/redistat.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/redistat/version', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name         = 'redistat'
-  gem.version      = Redistat::Version
+  gem.version      = Redistat::VERSION
   gem.date         = '2013-01-15'
   gem.authors      = ['Joe DiVita']
   gem.email        = ['divita@bellycard.com']

--- a/redistat.gemspec
+++ b/redistat.gemspec
@@ -1,6 +1,9 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/redistat/version', __FILE__)
+
 Gem::Specification.new do |gem|
   gem.name         = 'redistat'
-  gem.version      =  Redistat::VERSION
+  gem.version      = Redistat::Version
   gem.date         = '2013-01-15'
   gem.authors      = ['Joe DiVita']
   gem.email        = ['divita@bellycard.com']


### PR DESCRIPTION
This now allows for Increment/Decrement/Find/Aggregation queries for multiple ids at once.

Incrementing / decrementing multiple ids: 

```
Visits.increment(id: [1001, 1002, 2003], timestamp: '2014-01-01')
Visits.decrement(id: [1001, 1002, 1003], timestamp: '2014-01-01')
```

Find for multiple ids at once: 

```
Visits.find(id: [1001, 1002, 2003], year: 2014, month: 1, day: 5)
```

Aggregations across multiple ids: 

```
Visits.aggregate(id: [1001, 1002, 2003], start_date: '2014-01-01', end_date: '2014-01-05')
```

Aggregations across multiple ids w/ data points at the specified interval: 

```
Visits.aggregate(id: [1001, 1002, 2003], start_date: '2014-01-01', end_date: '2014-01-05', interval: :days)
```

Again these are all optimized for performance by limiting the number of requests to Redis (each one of the above queries only makes one request to Redis).
