### PR TITLE
*WIP* Adding support for Unique Counters

### DIFF
--- a/lib/redistat/scripts/mgetbit.lua
+++ b/lib/redistat/scripts/mgetbit.lua
@@ -1,0 +1,19 @@
+local unique_ids_key = ARGV[1]
+local unique_id      = ARGV[2]
+
+local result = {}
+
+-- Get the index
+local unique_id_index = redis.call('HGET', unique_ids_key, unique_id)
+-- If it doesn't exists, return zeros for all the keys
+if unique_id_index == false then
+  for index, key in ipairs(KEYS) do
+    result[index] = 0
+  end
+else
+  for index, key in ipairs(KEYS) do
+    result[index] = redis.call('GETBIT', key, unique_id_index)
+  end
+end
+
+return result

--- a/lib/redistat/scripts/msetbit.lua
+++ b/lib/redistat/scripts/msetbit.lua
@@ -1,0 +1,15 @@
+local unique_ids_key = ARGV[1]
+local value          = ARGV[2]
+local unique_id      = ARGV[3]
+
+-- See if index of unique id exists
+-- If not, set it to = the length of the hash
+local unique_id_index = redis.call('HGET', unique_ids_key, unique_id)
+if unique_id_index == false then
+  unique_id_index = redis.call('HLEN', unique_ids_key)
+  redis.call('HSET', unique_ids_key, unique_id, unique_id_index)
+end
+
+for index, key in ipairs(KEYS) do
+  redis.call('SETBIT', key, unique_id_index, value)
+end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -426,6 +426,44 @@ describe Redistat::Model do
     end
 
     describe '#find' do
+      context 'single ids' do
+        before do
+          Customers.increment(id: @id, timestamp: @timestamp, unique_id: @user1)
+        end
+
+        it 'finds the value for a unique id on a single day' do
+          expect(Customers.find(id: @id, year: 2014, month: 1, day: 5, unique_id: @user1)).to eq(1)
+          expect(Customers.find(id: @id, year: 2014, month: 1, day: 5, unique_id: 1)).to eq(0)
+        end
+
+        it 'finds the value for a unique id in a single week' do
+          expect(Customers.find(id: @id, year: 2014, week: 1, unique_id: @user1)).to eq(1)
+          expect(Customers.find(id: @id, year: 2014, week: 1, unique_id: 1)).to eq(0)
+        end
+
+        it 'finds the value for a unique id in a single month' do
+          expect(Customers.find(id: @id, year: 2014, month: 1, unique_id: @user1)).to eq(1)
+          expect(Customers.find(id: @id, year: 2014, month: 1, unique_id: 1)).to eq(0)
+        end
+
+        it 'finds the value for a unique id in a single year' do
+          expect(Customers.find(id: @id, year: 2014, unique_id: @user1)).to eq(1)
+          expect(Customers.find(id: @id, year: 2014, unique_id: 1)).to eq(0)
+        end
+      end
+
+      context 'mutiple ids' do
+        before do
+          2.times { Customers.increment(id: 1001, timestamp: @timestamp, unique_id: @user1) }
+          Customers.increment(id: 1002, timestamp: @timestamp, unique_id: @user1)
+        end
+
+        it 'returns an array of the values for each id' do
+          expected_result = [1, 1, 0]
+          params = { id: [1001, 1002, 1003], year: 2014, month: 1, day: 5, unique_id: @user1 }
+          expect(Customers.find(params)).to eq(expected_result)
+        end
+      end
     end
 
     describe '#aggregate' do

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -371,29 +371,31 @@ describe Redistat::Model do
     end
 
     describe '#increment' do
-      before do
-        Customers.increment(id: @id, timestamp: @timestamp, unique_id: @user1)
-        Customers.increment(id: @id, timestamp: @timestamp, unique_id: @user2)
-      end
+      context 'single ids' do
+        before do
+          Customers.increment(id: @id, timestamp: @timestamp, unique_id: @user1)
+          Customers.increment(id: @id, timestamp: @timestamp, unique_id: @user2)
+        end
 
-      it 'increments user1 by setting the bit at index 0 to 1' do
-        expect(Redistat::Connection.redis.getbit(@day_key, 0)).to eq(1)
-      end
+        it 'increments user1 by setting the bit at index 0 to 1' do
+          expect(Redistat::Connection.redis.getbit(@day_key, 0)).to eq(1)
+        end
 
-      it 'increments user2 by setting the bit at index 1 to 1' do
-        expect(Redistat::Connection.redis.getbit(@day_key, 1)).to eq(1)
-      end
+        it 'increments user2 by setting the bit at index 1 to 1' do
+          expect(Redistat::Connection.redis.getbit(@day_key, 1)).to eq(1)
+        end
 
-      it 'increments the bit on the week key' do
-        expect(Redistat::Connection.redis.getbit(@week_key, 0)).to eq(1)
-      end
+        it 'increments the bit on the week key' do
+          expect(Redistat::Connection.redis.getbit(@week_key, 0)).to eq(1)
+        end
 
-      it 'increments the bit on the month key' do
-        expect(Redistat::Connection.redis.getbit(@month_key, 0)).to eq(1)
-      end
+        it 'increments the bit on the month key' do
+          expect(Redistat::Connection.redis.getbit(@month_key, 0)).to eq(1)
+        end
 
-      it 'increments the bit on the year key' do
-        expect(Redistat::Connection.redis.getbit(@year_key, 0)).to eq(1)
+        it 'increments the bit on the year key' do
+          expect(Redistat::Connection.redis.getbit(@year_key, 0)).to eq(1)
+        end
       end
 
       context 'multiple ids' do
@@ -410,6 +412,17 @@ describe Redistat::Model do
     end
 
     describe '#decrement' do
+      before do
+        # First set the bit to 1
+        Redistat::Connection.redis.setbit(@day_key, 0, 1)
+      end
+
+      it 'decrements user1 by setting the bit at index 0 to 0' do
+        # Make sure it was properly set to 1 first
+        expect(Redistat::Connection.redis.getbit(@day_key, 0)).to eq(1)
+        Customers.decrement(id: @id, timestamp: @timestamp, unique_id: @user1)
+        expect(Redistat::Connection.redis.getbit(@day_key, 0)).to eq(0)
+      end
     end
 
     describe '#find' do


### PR DESCRIPTION
Adding support for Unique Counters.

Unique counters are used when an event with the same unique_id should not be counted twice.  A general example of this could be a counter for the number of users that visited a place. In this case the "id" parameter would represent the id of the place and the unique_id would be the users id.

Unique counters utilize Redis bitmaps and although their api is the same as regular counters, their implementations of the same methods are slightly different. 

This pull request enables the following:

Incrementing / Decrementing (which essentially just set bits to 1 or 0 for that particular unique id)

``` ruby
Customers.increment(id: 1, timestamp: '2014-01-05', unique_id: 1000)
Customers.decrement(id: 1, timestamp: '2014-01-05', unique_id: 1001)
```

Find: 

``` ruby
Customers.find(id: 1, year: 2014, month: 1, day: 5, unique_id: 1000) # Returns 0 or 1
```

TODO: implement aggregation methods to find total unique's for a given id across a timespan.

TODO: Right now unique_ids are indexed at the model level, rather than at the id level.

TODO: **If the above ^^^ then for aggregations across multiple ids: need to take into account that the same unique_id will not necessarily have the same index on each id's individual bitmap**

Both methods support batch queries for multiple keys at once.

For memory optimization, indexes on the bitmaps do not match the unique_id exactly.  Doing that would mean that a unique_id of 10000 would create a bitmap of size 100000 for just one unique_id.  Instead, each model of type :unique has an associated unique_ids index hash, which maps the unique_id with its associated index on the bitmap.   
