### PR TITLE
Adding support for unique counters

### DIFF
--- a/lib/redistat/scripts/msadd.lua
+++ b/lib/redistat/scripts/msadd.lua
@@ -1,0 +1,3 @@
+for index, key in ipairs(KEYS) do
+  redis.call('sadd', key, ARGV[1])
+end

--- a/lib/redistat/scripts/msismember.lua
+++ b/lib/redistat/scripts/msismember.lua
@@ -1,0 +1,7 @@
+local result = {}
+
+for index, key in ipairs(KEYS) do
+  result[index] = redis.call('sismember', key, ARGV[1])
+end
+
+return result

--- a/lib/redistat/scripts/msrem.lua
+++ b/lib/redistat/scripts/msrem.lua
@@ -1,0 +1,3 @@
+for index, key in ipairs(KEYS) do
+  redis.call('srem', key, ARGV[1])
+end

--- a/lib/redistat/scripts/msunion.lua
+++ b/lib/redistat/scripts/msunion.lua
@@ -1,0 +1,10 @@
+-- SPECIAL: ARGV[1] -> tempkey
+
+-- union all of the keys
+redis.call('sunionstore', ARGV[1], unpack(KEYS))
+-- get the cardinality of the resulting set
+local count = redis.call('scard', ARGV[1])
+-- delete the temp key
+redis.call('del', ARGV[1])
+
+return count

--- a/lib/redistat/scripts/union_data_points_for_keys.lua
+++ b/lib/redistat/scripts/union_data_points_for_keys.lua
@@ -1,0 +1,29 @@
+-- SPECIAL: ARGV[1] -> number_of_ids
+-- SPECIAL: ARGV[2] -> temp_key
+
+local result = {}
+local number_of_ids = tonumber(ARGV[1])
+local data_point_index = 2
+local count = 1
+
+-- union all of the keys
+redis.call('sunionstore', ARGV[2], unpack(KEYS))
+-- get the cardinality of the resulting set
+result[1] = redis.call('scard', ARGV[2])
+-- delete the temp key
+redis.call('del', ARGV[1])
+
+-- This loop fills returns the union of all the keys (for any number of ids) for each data point interval
+local index = 1
+while KEYS[index] do
+  local keys = {}
+  for i=0,(number_of_ids-1) do
+    keys[i+1] = KEYS[index+i]
+  end
+  redis.call('sunionstore', ARGV[2], unpack(keys))
+  result[data_point_index] = redis.call('scard', ARGV[2])
+  data_point_index = data_point_index + 1
+  index = index + number_of_ids
+end
+
+return result


### PR DESCRIPTION
Adding support for Unique Counters

Unique counters are used when an event with the same unique_id should not be counted twice. A general example of this could be a counter for the number of users that visited a place. In this case the "id" parameter would represent the id of the place and the unique_id would be the users id.

Unique counters utilize Redis sets and although their api is the same as regular counters, their implementations of the same methods are slightly different.

This pull request enables the following:

Incrementing / Decrementing (which essentially just adds the unique id to the set for that particular id / time):

``` ruby
Customers.increment(id: 1, timestamp: '2014-01-05', unique_id: 1000)
Customers.decrement(id: 1, timestamp: '2014-01-05', unique_id: 1000)
```

Find: 

``` ruby
Customers.find(id: 1, year: 2014, month: 1, day: 5, unique_id: 1000) # Returns true or false
```

Find the aggregate total over a datespan (this would only return the **unique** aggregate total):

``` ruby
Customers.aggregate(id: 1, start_date: '2014-01-01', end_date: '2014-01-05')
```

Find the aggregate total + data points for each point at a specified interval (again, this returns not only the **unique** aggregate total, but also the unique total for each interval data point ~ being each day / week / month / year...etc)

``` ruby
Customers.aggregate(id: 1, start_date: '2014-01-01', end_date: '2014-01-05', interval: :days)
```

All of these methods also support mutiple ids.  For example, we can find the unique aggregate totals across multiple ids by doing: 

``` ruby
Customers.aggregate(id: [1,2,3], start_date: '2014-01-01', end_date: '2014-01-05', interval: :days)
```
