### PR TITLE
Adding support for attributes + unique counters with no associated id

### DIFF
--- a/lib/redistat/model.rb
+++ b/lib/redistat/model.rb
@@ -40,7 +40,7 @@ module Redistat
         params.merge!(timestamp: timestamp)
 
         # Handle multiple ids
-        ids = id_param_to_array(params[:id])
+        ids = param_to_array(params[:id])
 
         ids.each do |id|
           params[:id] = id
@@ -89,7 +89,8 @@ module Redistat
             argv << key_data[1].shift # Only need the # of business ids (which is 1st element) from key_data[1]
             argv << temp_key
             if params[:attributes].present?
-              params[:attributes].each do |attribute|
+              attributes = param_to_array(params[:attributes])
+              attributes.each do |attribute|
                 keys << attribute_key(attribute)
                 argv << 1
               end
@@ -119,7 +120,8 @@ module Redistat
             argv = []
             argv << temp_key
             if params[:attributes].present?
-              params[:attributes].each do |attribute|
+              attributes = param_to_array(params[:attributes])
+              attributes.each do |attribute|
                 keys << attribute_key(attribute)
                 argv << 1
               end
@@ -151,7 +153,7 @@ module Redistat
           argv = []
 
           # Handle multiple keys
-          ids = id_param_to_array(params[:id])
+          ids = param_to_array(params[:id])
 
           ids.each do |id|
             params[:id] = id
@@ -173,7 +175,7 @@ module Redistat
           keys  = []
           dates = []
           argv  = []
-          ids   = id_param_to_array(params[:id])
+          ids   = param_to_array(params[:id])
 
           argv << ids.size
           start_date = Date.parse(params[:start_date]) if params[:start_date].is_a?(String)
@@ -263,9 +265,9 @@ module Redistat
           end
         end
 
-        def id_param_to_array(param_id)
-          ids = []
-          param_id.is_a?(Array) ? ids = param_id : ids << param_id
+        def param_to_array(param)
+          result = []
+          param.is_a?(Array) ? result = param : result << param
         end
 
         def temp_key

--- a/lib/redistat/scripts/msunion.lua
+++ b/lib/redistat/scripts/msunion.lua
@@ -1,9 +1,27 @@
 -- SPECIAL: ARGV[1] -> tempkey
+-- SPECIAL: All ARGV[n], where n > 1, signify an attribute
+-- SPECIAL: last n keys, where n is number of attributes, is keys associated with attributes
+
+local num_attributes = table.getn(ARGV) - 1
+local attribute_keys = {}
+
+-- Remove keys associated with attributes and add them to our own attributes_keys array
+for i=1,num_attributes do
+  table.insert(attribute_keys, table.remove(KEYS))
+end
 
 -- union all of the keys
 redis.call('sunionstore', ARGV[1], unpack(KEYS))
+
+-- If attributes are present, we want to get the intersect of the result + any attributes and store in ARGV[1]
+if num_attributes > 0 then
+  table.insert(attribute_keys, ARGV[1])
+  redis.call('sinterstore', ARGV[1], unpack(attribute_keys))
+end
+
 -- get the cardinality of the resulting set
 local count = redis.call('scard', ARGV[1])
+
 -- delete the temp key
 redis.call('del', ARGV[1])
 

--- a/lib/redistat/scripts/union_data_points_for_keys.lua
+++ b/lib/redistat/scripts/union_data_points_for_keys.lua
@@ -1,19 +1,32 @@
 -- SPECIAL: ARGV[1] -> number_of_ids
 -- SPECIAL: ARGV[2] -> temp_key
+-- SPECIAL: All ARGV[n], where n > 2, signify an attribute
+-- SPECIAL: last n keys, where n is number of attributes, is keys associated with attributes
 
 local result = {}
 local number_of_ids = tonumber(ARGV[1])
 local data_point_index = 2
 local count = 1
+local num_attributes = table.getn(ARGV) - 2
+local attribute_keys = {}
+
+-- Remove keys associated with attributes and add them to our own attributes_keys array
+for i=1,num_attributes do
+  table.insert(attribute_keys, table.remove(KEYS))
+end
 
 -- union all of the keys
 redis.call('sunionstore', ARGV[2], unpack(KEYS))
+
+-- If attribute are present, we want to get the intersect of the result + any attributes and store in ARGV[2]
+if num_attributes > 0 then
+  redis.call('sinterstore', ARGV[2], ARGV[2], unpack(attribute_keys))
+end
+
 -- get the cardinality of the resulting set
 result[1] = redis.call('scard', ARGV[2])
--- delete the temp key
-redis.call('del', ARGV[1])
 
--- This loop fills returns the union of all the keys (for any number of ids) for each data point interval
+-- This loop returns the union of all the keys (for any number of ids) for each data point interval
 local index = 1
 while KEYS[index] do
   local keys = {}
@@ -21,9 +34,18 @@ while KEYS[index] do
     keys[i+1] = KEYS[index+i]
   end
   redis.call('sunionstore', ARGV[2], unpack(keys))
+
+  -- If attributes are present, we want to get the interset of this data points result + any attributes
+  if num_attributes > 0 then
+    redis.call('sinterstore', ARGV[2], ARGV[2], unpack(attribute_keys))
+  end
+
   result[data_point_index] = redis.call('scard', ARGV[2])
   data_point_index = data_point_index + 1
   index = index + number_of_ids
 end
+
+-- delete the temp key
+redis.call('del', ARGV[2])
 
 return result

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -471,7 +471,6 @@ describe Redistat::Model do
         it 'returns the total over the date range' do
           9.times { |day| Redistat::Connection.redis.sadd("app1:customers:2014-01-0#{day + 1}:#{@id}", @user1) }
           3.times { |day| Redistat::Connection.redis.sadd("app1:customers:2014-01-0#{day + 1}:#{@id}", @user2) }
-          result = Redistat::Connection.redis.sunion("app1:customers:")
           result = Customers.aggregate(start_date: '2014-01-01', end_date: '2014-01-09', id: @id)
           expect(result).to eq(2)
         end
@@ -627,6 +626,143 @@ describe Redistat::Model do
           it 'returns the correct data for each point in the interval' do
             3.times { |num| expect(@result[:days][num][:customers]).to eq(2) }
             (3..8).each { |num| expect(@result[:days][num][:customers]).to eq(1) }
+          end
+        end
+      end
+    end
+  end
+
+  context 'attributes' do
+    before do
+      class Customers < Redistat::Model
+        type        :unique
+        resolution  :days
+      end
+      class Males < Redistat::Model
+        type :unique
+      end
+      class Mobile < Redistat::Model
+        type :unique
+      end
+      @user1         = 1111
+      @user2         = 2222
+      @user3         = 3333
+      @attribute_key = 'app1:males'
+    end
+
+    describe '#increment' do
+      before do
+        Males.increment(unique_id: @user1)
+        Males.increment(unique_id: @user2)
+      end
+
+      it 'adds user1 to the set' do
+        result = Redistat::Connection.redis.sismember(@attribute_key, @user1)
+        expect(result).to be true
+      end
+
+      it 'adds user2 to the set' do
+        result = Redistat::Connection.redis.sismember(@attribute_key, @user2)
+        expect(result).to be true
+      end
+    end
+
+    describe '#decrement' do
+      before do
+        Males.increment(unique_id: @user1)
+      end
+
+      it 'adds user1 to the set' do
+        Males.decrement(unique_id: @user1)
+        result = Redistat::Connection.redis.sismember(@attribute_key, @user1)
+        expect(result).to be false
+      end
+    end
+
+    describe '#find' do
+      before do
+        Males.increment(unique_id: @user1)
+      end
+
+      it 'returns 1 for a unique_id that is in the attribute set' do
+        expect(Males.find(unique_id: @user1)).to eq(1)
+      end
+
+      it 'returns 0 for a unique_id that is not in the attribute set' do
+        expect(Males.find(unique_id: @user2)).to eq(0)
+      end
+    end
+
+    describe '#aggregate' do
+      before do
+        Males.increment(unique_id: @user1)
+        Males.increment(unique_id: @user2)
+        Mobile.increment(unique_id: @user2)
+        9.times{ |day| Redistat::Connection.redis.sadd("app1:customers:2014-01-0#{day + 1}:#{2222}", @user1) }
+        3.times{ |day| Redistat::Connection.redis.sadd("app1:customers:2014-01-0#{day + 1}:#{1111}", @user2) }
+        3.times{ |day| Redistat::Connection.redis.sadd("app1:customers:2014-01-0#{day + 1}:#{1111}", @user3) }
+        @params = { id: [1111, 2222], start_date: '2014-01-01', end_date: '2014-01-09' }
+        @attributes = []
+      end
+
+      context 'when no interval is specified' do
+        context 'and single attribute is specified' do
+          it 'returns the total over the date range' do
+            @attributes << :males
+            result = Customers.aggregate(@params.merge!(attributes: @attributes))
+            expect(result).to eq(2)
+          end
+        end
+
+        context 'and multiple attributes are specified' do
+          it 'returns the total over the date range' do
+            @attributes << :males
+            @attributes << :mobile
+            result = Customers.aggregate(@params.merge!(attributes: @attributes))
+            expect(result).to eq(1)
+          end
+        end
+      end
+
+      context 'when interval is specified' do
+        context 'and single attribute is specified' do
+          before do
+            @attributes << :males
+            @result = Customers.aggregate(@params.merge!(attributes: @attributes, interval: :days))
+          end
+
+          it 'returns the total over the date range' do
+            expect(@result[:customers]).to eq(2)
+          end
+
+          it 'returns the proper amount of data points' do
+            expect(@result[:days].size).to eq(9)
+          end
+
+          it 'returns the correct data for each point in the interval' do
+            3.times { |num| expect(@result[:days][num][:customers]).to eq(2) }
+            6.times { |num| expect(@result[:days][num + 3][:customers]).to eq(1) }
+          end
+        end
+
+        context 'and multiple attributes are specified' do
+          before do
+            @attributes << :males
+            @attributes << :mobile
+            @result = Customers.aggregate(@params.merge!(attributes: @attributes, interval: :days))
+          end
+
+          it 'returns the total over the date range' do
+            expect(@result[:customers]).to eq(1)
+          end
+
+          it 'returns the proper amount of data points' do
+            expect(@result[:days].size).to eq(9)
+          end
+
+          it 'returns the correct data for each point in the interval' do
+            3.times { |num| expect(@result[:days][num][:customers]).to eq(1) }
+            6.times { |num| expect(@result[:days][num + 3][:customers]).to eq(0) }
           end
         end
       end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -712,6 +712,11 @@ describe Redistat::Model do
             result = Customers.aggregate(@params.merge!(attributes: @attributes))
             expect(result).to eq(2)
           end
+
+          it 'does not require use of an array if specifying only one attribute' do
+            result = Customers.aggregate(@params.merge!(attributes: :males))
+            expect(result).to eq(2)
+          end
         end
 
         context 'and multiple attributes are specified' do


### PR DESCRIPTION
Adding support for using other unique counters as "attributes" in queries.  

Attributes are unique counter stats that are not associated with an id (so kind of like "global" sets).  These can be mashed up with other unique countesr that are associated with ids, to give the same result as if they were associated with that id.  The main advantages for doing this are: 
- To save a tremendous amount of memory (don't have to store all this data, for every resolution interval, for every id)
- It's easier to update / maintain / rebuilding data is much quicker ( instead of having to update these values for every id at every interval, you can just do it once, at the "global" level ).

For example, lets say we have a unique counter "Customers", and a unique counter "Males".  Instead of storing them both at the id & daily level we can get the number of males / day / id with the following: 

``` ruby
class Customers < Redistat::Model
  type :unique
  resolution :days
end

class Males < Redistat::Model
  type :unique
end
```

Now you can query customers, just as you normally would, but if you want to mash it up against Males just pass in an attribute into the parameters: 

``` ruby
Customers.aggregate(id: 1, start_date, '2014-01-01', end_date: '2014-01-09', attributes: [:males])
```

You can even mash up multiple attributes.  Suppose I want to see all the customers who are male, and Android users.  First add the AndroidUsers class:

``` ruby
class AndroidUsers < Redistat::Model
  type: unique
end
```

then just add that into the query: 

``` ruby
Customers.aggregate(id: 1, start_date, '2014-01-01', end_date: '2014-01-09', attributes: [:males, :android_users])
```

All the methods available to unique counters can be used for unique counters acting as global attributes, with a few simplifications.  Obviously if it does not have a resolution, and is not associated with an id, then there is no need to pass those parameters into any of those methods.  

For example, adding / removing a unique_id to a global attribute set: 

``` ruby
Males.increment(unique_id: 1000)
Males.increment(unique_id: 1000)
```

or seeing if a unique_id is in a set: 

``` ruby
Males.find(unique_id: 1000)
```

TODO: Currently this only supports "ANDing" multiple attributes.  Would like to eventually add ORing functionality as well (ie Males OR AndroidUsers), but this is a start.
