### PR TITLE
adding ability to decrement / increment by a custom value

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redtastic (0.2.2)
+    redtastic (0.3.0)
       activesupport
       redis
 

--- a/lib/redtastic/model.rb
+++ b/lib/redtastic/model.rb
@@ -10,7 +10,12 @@ module Redtastic
           argv << params[:unique_id]
           Redtastic::ScriptManager.msadd(key_data[0], argv)
         else
-          Redtastic::ScriptManager.hmincrby(key_data[0], key_data[1].unshift(1))
+          if params[:by].present?
+            increment_by = params[:by]
+          else
+            increment_by = 1
+          end
+          Redtastic::ScriptManager.hmincrby(key_data[0], key_data[1].unshift(increment_by))
         end
       end
 
@@ -21,7 +26,12 @@ module Redtastic
           argv << params[:unique_id]
           Redtastic::ScriptManager.msrem(key_data[0], argv)
         else
-          Redtastic::ScriptManager.hmincrby(key_data[0], key_data[1].unshift(-1))
+          if params[:by].present?
+            decrement_by = params[:by]
+          else
+            decrement_by = 1
+          end
+          Redtastic::ScriptManager.hmincrby(key_data[0], key_data[1].unshift(-1*decrement_by))
         end
       end
 

--- a/lib/redtastic/version.rb
+++ b/lib/redtastic/version.rb
@@ -1,3 +1,3 @@
 module Redtastic
-  VERSION = '0.2.2'
+  VERSION = '0.3.0'
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -63,6 +63,18 @@ describe Redtastic::Model do
         end
       end
 
+      context 'when specifying the \'by\' parameter' do
+        it 'increments the key by the given amount' do
+          Visits.increment(timestamp: @timestamp, id: @id, by: 5)
+          expect(Redtastic::Connection.redis.hget(@day_key, @index)).to eq('5')
+        end
+
+        it 'allows for negative increments' do
+          Visits.increment(timestamp: @timestamp, id: @id, by: -5)
+          expect(Redtastic::Connection.redis.hget(@day_key, @index)).to eq('-5')
+        end
+      end
+
       context 'a model with no resolution' do
         it 'increments the key' do
           NoResolutions.increment(id: @id)
@@ -85,14 +97,26 @@ describe Redtastic::Model do
     end
 
     describe '#decrement' do
-      before do
-        Redtastic::Connection.redis.hset(@day_key, @index, '1')
-        Visits.decrement(timestamp: @timestamp, id: @id)
-      end
-
       context 'a model with a resolution' do
+        before do
+          Redtastic::Connection.redis.hset(@day_key, @index, '1')
+          Visits.decrement(timestamp: @timestamp, id: @id)
+        end
+
         it 'decrements the key' do
           expect(Redtastic::Connection.redis.hget(@day_key, @index)).to eq('0')
+        end
+      end
+
+      context 'when specifying the \'by\' parameter' do
+        it 'decrements the key by the given amount' do
+          Visits.decrement(timestamp: @timestamp, id: @id, by: 5)
+          expect(Redtastic::Connection.redis.hget(@day_key, @index)).to eq('-5')
+        end
+
+        it 'allows for negative decrements' do
+          Visits.decrement(timestamp: @timestamp, id: @id, by: -5)
+          expect(Redtastic::Connection.redis.hget(@day_key, @index)).to eq('5')
         end
       end
 


### PR DESCRIPTION
Allows you to increment / decrement a counter data type by more than just 1:

```
Visits.increment(id: 1, timestamp: '2014-01-01', by: 5)
Visits.decrement(id: 1, timestamp: '2014-01-01', by: 5)
```

@jdoconnor 
