### PR TITLE
Fix week interval data

### DIFF
--- a/lib/redtastic/model.rb
+++ b/lib/redtastic/model.rb
@@ -235,7 +235,7 @@ module Redtastic
             timestamp.strftime('%Y-%m-%d')
           when :weeks
             week_number = timestamp.cweek
-            result = timestamp.strftime('%Y')
+            result = timestamp.cwyear.to_s
             result + "-W#{week_number}"
           when :months
             timestamp.strftime('%Y-%m')

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -267,27 +267,43 @@ describe Redtastic::Model do
         end
 
         context 'and is weeks' do
-          before do
-            @params[:interval] = :weeks
-            @result = Visits.aggregate(@params)
+          context 'for weeks in the same year' do
+            before do
+              @params[:interval] = :weeks
+              @result = Visits.aggregate(@params)
+            end
+
+            it 'returns the total over the date range' do
+              expect(@result[:visits]).to eq(8)
+            end
+
+            it 'returns the proper amount of data points' do
+              expect(@result[:weeks].size).to eq(2)
+            end
+
+            it 'returns the correct data for each point in the interval' do
+              expect(@result[:weeks][0][:visits]).to eq(5)
+              expect(@result[:weeks][1][:visits]).to eq(3)
+            end
+
+            it 'returns the correct dates for each point in the interval' do
+              expect(@result[:weeks][0][:date]).to eq('2014-W1')
+              expect(@result[:weeks][1][:date]).to eq('2014-W2')
+            end
           end
 
-          it 'returns the total over the date range' do
-            expect(@result[:visits]).to eq(8)
-          end
+          context 'for weeks over two different years' do
+            before do
+              @params[:interval] = :weeks
+              @params[:start_date] = '2015-12-25'
+              @params[:end_date] = '2016-01-03'
+              @result = Visits.aggregate(@params)
+            end
 
-          it 'returns the proper amount of data points' do
-            expect(@result[:weeks].size).to eq(2)
-          end
-
-          it 'returns the correct data for each point in the interval' do
-            expect(@result[:weeks][0][:visits]).to eq(5)
-            expect(@result[:weeks][1][:visits]).to eq(3)
-          end
-
-          it 'returns the correct dates for each point in the interval' do
-            expect(@result[:weeks][0][:date]).to eq('2014-W1')
-            expect(@result[:weeks][1][:date]).to eq('2014-W2')
+            it 'returns the correct dates' do
+              expect(@result[:weeks][0][:date]).to eq('2015-W52')
+              expect(@result[:weeks][1][:date]).to eq('2015-W53')
+            end
           end
         end
 


### PR DESCRIPTION
Comparison without whitespace: https://github.com/bellycard/redtastic/pull/37/files?w=0

Happy 2016! This new year exposed an edge case when we did an aggregation of metrics over a few weeks, spanning over two different years. Here's a specific example:

```
[1] > Date.parse('2016-01-01')
=> Fri, 01 Jan 2016
[2] > Date.parse('2016-01-01').cweek
=> 53
[3] > Date.parse('2016-01-01').cwyear.to_s
=> "2015"
[4] > Date.parse('2016-01-01').strftime('%Y')
=> "2016"
```

Notice the different years returned by `cwyear` vs `strftime('%Y')` respectively. As a result, the metrics that were returned initially had `2016-W53` for the time period starting with `2016-01-01` when it should have been `2015-W53`.

@bellycard/platform cc @brousalis 
