### PR TITLE
version bump (for fix with weekly metrics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+master
+======
+* Added a CHANGELOG
+* [Fix for dates on weekly metrics](https://github.com/bellycard/redtastic/pull/37)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redtastic (0.3.2)
+    redtastic (0.3.3)
       activesupport
       redis
 

--- a/lib/redtastic/version.rb
+++ b/lib/redtastic/version.rb
@@ -1,3 +1,3 @@
 module Redtastic
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end


### PR DESCRIPTION
I forgot to bump the version for this fix: https://github.com/bellycard/redtastic/pull/37

Once this is merged, I will push it up to Rubygems.

@bellycard/platform
