### PR TITLE
Adding new script for hmget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 master
 ======
-* Added a CHANGELOG
+
+0.3.5
+=====
+* [Added hmsum Lua script that uses Redis hmget](https://github.com/bellycard/redtastic/pull/40)
 
 0.3.4
 =====
@@ -9,3 +12,4 @@ master
 0.3.3
 =====
 * [Fix for dates on weekly metrics](https://github.com/bellycard/redtastic/pull/37)
+* Added a CHANGELOG

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redtastic (0.3.4)
+    redtastic (0.3.5)
       activesupport
       redis
 

--- a/lib/redtastic/scripts/hmsum.lua
+++ b/lib/redtastic/scripts/hmsum.lua
@@ -17,10 +17,11 @@
 
 local sum = 0
 
-for _, key in ipairs(KEYS) do
-  local value_array = redis.call('HMGET', key, unpack(ARGV))
+for i=1,#KEYS do
+  local value_array = redis.call('HMGET', KEYS[i], unpack(ARGV))
 
-  for _, elem in ipairs(value_array) do
+  for j=1,#value_array do
+    local elem = value_array[j]
     if elem then
       sum = sum + tonumber(elem)
     end

--- a/lib/redtastic/scripts/hmsum.lua
+++ b/lib/redtastic/scripts/hmsum.lua
@@ -1,0 +1,30 @@
+-- Returns the total sum of the values for each key in KEYS, across multiple ids in ARGV
+-- KEYS: [ "key1", "key2" ]
+-- ARGV: [1, 2, 3]
+
+-- Example data structures
+-- hkeys key1
+-- => "1" => "1", "2" => "4"
+-- hkeys key2
+-- => "2" => "3", "3" => "5"
+-- hmget key1 1 2 3
+-- => ["1", "4", nil]
+-- hmget key2 1 2 3
+-- => [nil, "3", "5"]
+
+-- This script will evaluate the above data structure and sum the result of the array values
+-- that match the ids in ARGV. i.e. The example above will return 5 + 8 = 13
+
+local sum = 0
+
+for _, key in ipairs(KEYS) do
+  local value_array = redis.call('HMGET', key, unpack(ARGV))
+
+  for _, elem in ipairs(value_array) do
+    if elem then
+      sum = sum + tonumber(elem)
+    end
+  end
+end
+
+return sum

--- a/lib/redtastic/version.rb
+++ b/lib/redtastic/version.rb
@@ -1,3 +1,3 @@
 module Redtastic
-  VERSION = '0.3.4'
+  VERSION = '0.3.5'
 end


### PR DESCRIPTION
@sisk and I were in a dark place today.

Adding this script so we can use it for `hmget` calls in BAS. Being able to load and run this script on BAS will save us from making unnecessary calls to Redis from Ruby, which has led to ridiculous network latency as seen on NewRelic. Corresponding BAS PR to come.

@sisk @darbyfrey 
@bellycard/platform  

cc @joedivita 
